### PR TITLE
[FIX] Simplifying CSS and elements IDs on widget load

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,7 +77,7 @@ app.locals.click2voxScripts = [
 app.locals.globalCss = [
   '//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
   app.locals.docroot+"/stylesheets/root.css",
-  app.locals.docroot+"/stylesheets/widget.css"
+  app.locals.docroot+"/stylesheets/widget-0.4.css"
 ];
 
 module.exports = app;

--- a/public/javascripts/widget-0.4.js
+++ b/public/javascripts/widget-0.4.js
@@ -6,7 +6,7 @@ function loadWidget() {
   $("<link/>", {
      rel: "stylesheet",
      type: "text/css",
-     href: docroot + "/stylesheets/widget.css"
+     href: docroot + "/stylesheets/widget-0.4.css"
   }).appendTo("head");
 
   $('#vox-control').append(' \

--- a/public/stylesheets/widget-0.4.css
+++ b/public/stylesheets/widget-0.4.css
@@ -1,49 +1,13 @@
 @import url(//cdnjs.cloudflare.com/ajax/libs/raty/2.7.0/jquery.raty.css);
 @import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,700,400italic);
 
-/* Fonts */
-body,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4 {
+.vox-widget-wrapper, #vox-control{
   font-family: 'Open Sans', sans-serif;
-  color: #343c3e;
-  font-weight: normal;
 }
 
-body.test {
-  position: absolute;
-  padding: 0;
-  margin: 0;
-  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
-  width: 100%;
-  height: 100%;
-}
-
-body.test iframe{
-  border: none;
-  position: absolute;
-  top:0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-a {
-  color: #781e75;
-  text-decoration: none;
-}
 .hidden{
   display: none !important;
 }
-
 
 .vox-widget-wrapper{
   z-index: 10000;
@@ -425,19 +389,258 @@ span:nth-child(3).vw-animated-dots  {
   -moz-animation-delay: 500ms;
 }
 
-
-.vox-widget-wrapper input[type="text"]{
-  display: block;
-  width: 100%;
-  height: 34px;
-  padding: 6px 12px;
+/* Widget Style */
+/*Btn Widget Stuff*/
+.btn-style-a {
+  display: inline-block;
+  border: 1px solid #17a0f3;
+  padding: 0;
+  margin-right: 10px;
+  text-decoration: none;
   font-size: 14px;
-  line-height: 1.42857143;
-  color: #555;
-  background-color: #fff;
-  background-image: none;
-  border: 1px solid #ccc;
+  text-align: center;
+  line-height: 1.4;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  -webkit-user-select: none;
+  background: #19a1f3;
+  background: -webkit-linear-gradient(#19a1f3, #0b85ce);
+  background: -moz-linear-gradient(#19a1f3, #19a1f3);
+  background: -ms-linear-gradient(#19a1f3, #19a1f3);
+  background: -o-linear-gradient(#19a1f3, #19a1f3);
+  background: linear-gradient(#19a1f3, #0b85ce);
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
   border-radius: 4px;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -ms-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -o-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+}
+.btn-style-a span {
+  display: block;
+  min-width: 120px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-shadow: 0px -1px #07619E;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.btn-style-a:hover {
+  background: -webkit-linear-gradient(#0b85ce, #19a1f3);
+  background: -moz-linear-gradient(#0b85ce, #19a1f3);
+  background: -ms-linear-gradient(#0b85ce, #19a1f3);
+  background: -o-linear-gradient(#0b85ce, #19a1f3);
+  background: linear-gradient(#0b85ce, #19a1f3);
+}
+.btn-style-b {
+  display: inline-block;
+  border: 1px solid #90168c;
+  padding: 0;
+  margin-right: 10px;
+  text-decoration: none;
+  font-size: 14px;
+  text-align: center;
+  line-height: 1.4;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  -webkit-user-select: none;
+  background: #92168e;
+  background: -webkit-linear-gradient(#92168e, #660f63);
+  background: -moz-linear-gradient(#92168e, #92168e);
+  background: -ms-linear-gradient(#92168e, #92168e);
+  background: -o-linear-gradient(#92168e, #92168e);
+  background: linear-gradient(#92168e, #660f63);
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -ms-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -o-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+}
+.btn-style-b span {
+  display: block;
+  min-width: 120px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-shadow: 0px -1px #07619E;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.btn-style-b:hover {
+  background: -webkit-linear-gradient(#660f63, #92168e);
+  background: -moz-linear-gradient(#660f63, #92168e);
+  background: -ms-linear-gradient(#660f63, #92168e);
+  background: -o-linear-gradient(#660f63, #92168e);
+  background: linear-gradient(#660f63, #92168e);
+}
+.widget-box {
+  position: relative;
+  padding: 70px;
+  text-align: center;
+  -webkit-border-radius: 6px;
+  -moz-border-radius: 6px;
+  border-radius: 6px;
+}
+.widget-box .widget-footer-left {
+  position: absolute;
+  font-size: 9px;
+  bottom: 8px;
+  left: 8px;
+}
+.widget-box .widget-footer-left a {
+  padding-right: 62px;
+}
+.widget-box .widget-footer-right {
+  position: absolute;
+  font-size: 9px;
+  bottom: 8px;
+  right: 8px;
+}
+.widget-box .widget-footer-right a {
+  padding-right: 62px;
+  background-image: url('../images/widget-brand.png');
+  background-size: 60px 12.5px;
+  background-position: right center;
+  background-repeat: no-repeat;
+}
+
+.widget-box .widget-footer-right.style-b a {
+  background-image: url('../images/widget-brand-white.png');
+  color: #f1f1f1;
+}
+
+.widget-box .widget-footer-right.style-a a {
+  background-image: url('../images/widget-brand.png');
+  color: #781e75
+}
+.widget-box .btn-style {
+  width: 100%;
+}
+.widget-box.style-a {
+  -webkit-box-shadow: inset 0px 0px 5px 0px #ffffff, 0px 0px 8px 0px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: inset 0px 0px 5px 0px #ffffff, 0px 0px 8px 0px rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0px 0px 5px 0px #ffffff, 0px 0px 8px 0px rgba(0, 0, 0, 0.2);
+  background: #f5f5f7;
+}
+.widget-box.style-a .btn-style {
+  display: inline-block;
+  border: 1px solid #17a0f3;
+  padding: 0;
+  margin-right: 10px;
+  text-decoration: none;
+  font-size: 14px;
+  text-align: center;
+  line-height: 1.4;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  -webkit-user-select: none;
+  background: #19a1f3;
+  background: -webkit-linear-gradient(#19a1f3, #0b85ce);
+  background: -moz-linear-gradient(#19a1f3, #19a1f3);
+  background: -ms-linear-gradient(#19a1f3, #19a1f3);
+  background: -o-linear-gradient(#19a1f3, #19a1f3);
+  background: linear-gradient(#19a1f3, #0b85ce);
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -ms-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -o-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+}
+.widget-box.style-a .btn-style span {
+  display: block;
+  min-width: 120px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-shadow: 0px -1px #07619E;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.widget-box.style-a .btn-style:hover {
+  background: -webkit-linear-gradient(#0b85ce, #19a1f3);
+  background: -moz-linear-gradient(#0b85ce, #19a1f3);
+  background: -ms-linear-gradient(#0b85ce, #19a1f3);
+  background: -o-linear-gradient(#0b85ce, #19a1f3);
+  background: linear-gradient(#0b85ce, #19a1f3);
+}
+.widget-box.style-a .widget-footer a {
+  color: #8b8b8b;
+}
+.widget-box.style-b {
+  -webkit-box-shadow: inset 0px 0px 5px 0px rgba(255, 255, 255, 0.5), 0px 0px 8px 0px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: inset 0px 0px 5px 0px rgba(255, 255, 255, 0.5), 0px 0px 8px 0px rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0px 0px 5px 0px rgba(255, 255, 255, 0.5), 0px 0px 8px 0px rgba(0, 0, 0, 0.2);
+  background: #2a2929;
+}
+.widget-box.style-b .btn-style {
+  display: inline-block;
+  border: 1px solid #90168c;
+  padding: 0;
+  margin-right: 10px;
+  text-decoration: none;
+  font-size: 14px;
+  text-align: center;
+  line-height: 1.4;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  -webkit-user-select: none;
+  background: #92168e;
+  background: -webkit-linear-gradient(#92168e, #660f63);
+  background: -moz-linear-gradient(#92168e, #92168e);
+  background: -ms-linear-gradient(#92168e, #92168e);
+  background: -o-linear-gradient(#92168e, #92168e);
+  background: linear-gradient(#92168e, #660f63);
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -ms-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  -o-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+}
+.widget-box.style-b .btn-style span {
+  display: block;
+  min-width: 120px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-shadow: 0px -1px #07619E;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.widget-box.style-b .btn-style:hover {
+  background: -webkit-linear-gradient(#660f63, #92168e);
+  background: -moz-linear-gradient(#660f63, #92168e);
+  background: -ms-linear-gradient(#660f63, #92168e);
+  background: -o-linear-gradient(#660f63, #92168e);
+  background: linear-gradient(#660f63, #92168e);
+}
+.widget-box.style-b .widget-footer a {
+  color: #d8d8d8;
 }


### PR DESCRIPTION
- Putting back old widget.css
- Creating widget-0.4.css (tied to widget.js version)